### PR TITLE
Changed FetchMany from using default header to instance based header

### DIFF
--- a/src/Enterspeed.Delivery.Sdk/Domain/Services/EnterspeedDeliveryService.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Services/EnterspeedDeliveryService.cs
@@ -135,7 +135,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
         {
             HttpResponseMessage response;
 
-            _enterspeedDeliveryConnection.HttpClientConnection.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+            content.Headers.Add("X-Api-Key", apiKey);
 
             if (cancellationToken.HasValue)
             {


### PR DESCRIPTION
On the first call to `FetchMany` API it's all good. However, on the second call before the connection timeout which is defaulted to 60 seconds. You will get 2 headers due to sharing the same `HttpClient` which is getting unauthorised: 
![image](https://github.com/enterspeedhq/enterspeed-sdk-delivery-dotnet/assets/63308868/895f3a88-f442-475d-9ab6-e85c2bc60851)

I've removed the default header and changed it to instance based header this has resolved the issue.

Also, another suggestion would be:
https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines

Since you are targeting .NET Standard 2.0 you'll have .NET Framework in there but when targeting .NET Core or .NET 5+ you'll want to use:
```
var handler = new SocketsHttpHandler
{
    PooledConnectionLifetime = TimeSpan.FromSeconds(60)
};
var sharedClient = new HttpClient(handler);
```

This will help prevent race conditions too.