### PR TITLE
Feature/4813/httpclient changes in delivery sdk

### DIFF
--- a/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
@@ -76,8 +76,6 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
             };
 #endif
 
-
-
             _httpClientConnection = httpClient;
 
             _httpClientConnection.DefaultRequestHeaders.Add("Accept", "application/json");

--- a/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
@@ -57,9 +57,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
                 throw new ConfigurationException(nameof(BaseUrl));
             }
 
-            HttpClient httpClient = null;
-
-
+            HttpClient httpClient;
 
 #if NETCOREAPP2_1_OR_GREATER
             var handler = new SocketsHttpHandler

--- a/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
@@ -57,10 +57,30 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
                 throw new ConfigurationException(nameof(BaseUrl));
             }
 
-            _httpClientConnection = new HttpClient
+            HttpClient httpClient = null;
+
+
+
+#if NETCOREAPP2_1_OR_GREATER
+            var handler = new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromSeconds(60)
+            };
+
+            httpClient = new HttpClient(handler)
             {
                 BaseAddress = new Uri(BaseUrl)
             };
+#else
+            httpClient = new HttpClient
+            {
+                BaseAddress = new Uri(BaseUrl)
+            };
+#endif
+
+
+
+            _httpClientConnection = httpClient;
 
             _httpClientConnection.DefaultRequestHeaders.Add("Accept", "application/json");
 


### PR DESCRIPTION
SocketsHttpHandler is only required for 2.1 and upwards. This should provide automatic DNS resolution and supports changes to DNS settings during the lifetime of the application.

Configuring PooledConnectionLifetime allows us to control how long connections are kept alive in the pool, preventing the accumulation of long-idle connections that may no longer be reliable or necessary.