### PR TITLE
Release/1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Fixed
+- Fixed thread-safety races in `EnterspeedDeliveryConnection` that could intermittently surface as `NullReferenceException` inside `EnterspeedDeliveryService` under concurrent load, or let a request observe a half-configured `HttpClient`. Each delivery operation now also uses one client capture for both building the request URI and sending the request.
+
+### Changed
+- On .NET Core 2.1+/.NET 5+ the `HttpClient` is no longer recreated on a timer. `ConnectionTimeout` now configures `SocketsHttpHandler.PooledConnectionLifetime` (previously hardcoded to 60 seconds, silently ignoring the configured value), which is the supported DNS-rotation mechanism for a long-lived client; `Flush()` still forces a new client on demand. On .NET Framework (the netstandard2.0 asset) timed recreation remains and is now measured with a monotonic clock.
+- `ConnectionTimeout` values less than or equal to 0 are treated as 1 second instead of recreating the client on every request.
+- `AddEnterspeedDeliveryService` now registers the connection as a singleton (previously transient) and also registers it as `IEnterspeedDeliveryConnection`.
+- `EnterspeedDeliveryConnection` now throws `ObjectDisposedException` when used after disposal, and `Dispose()` is idempotent.
+
 ## [1.5.0 - 2025-10-01]
 ### Added
   - Added support for fetching views as strongly typed (.net 6 and up)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.6.0 - 2026-07-07]
 ### Fixed
 - Fixed thread-safety races in `EnterspeedDeliveryConnection` that could intermittently surface as `NullReferenceException` inside `EnterspeedDeliveryService` under concurrent load, or let a request observe a half-configured `HttpClient`. Each delivery operation now also uses one client capture for both building the request URI and sending the request.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   majorVersion: 1
-  minorVersion: 5
+  minorVersion: 6
   patchVersion: 0
   version: $[format('{0}.{1}.{2}', variables.majorVersion, variables.minorVersion, variables.patchVersion)]
   agentPool: Enterspeed-Production

--- a/src/Enterspeed.Delivery.Sdk/Api/Connection/IEnterspeedDeliveryConnection.cs
+++ b/src/Enterspeed.Delivery.Sdk/Api/Connection/IEnterspeedDeliveryConnection.cs
@@ -1,16 +1,26 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 
 namespace Enterspeed.Delivery.Sdk.Api.Connection
 {
     public interface IEnterspeedDeliveryConnection
     {
         /// <summary>
-        /// Gets the configured HttpClient.
+        /// Gets the SDK-owned <see cref="HttpClient"/>.
+        /// The returned instance is shared between all callers. Only the Send-family methods
+        /// (<c>SendAsync</c>, <c>GetAsync</c>, <c>PostAsync</c>, ...) are thread safe on it — do not
+        /// mutate <see cref="HttpClient.DefaultRequestHeaders"/>, <see cref="HttpClient.BaseAddress"/>
+        /// or other properties: <c>DefaultRequestHeaders</c> is not thread safe and must not be modified
+        /// while requests are outstanding. The instance can be replaced (by <see cref="Flush"/>, or by
+        /// the timed refresh on .NET Framework/netstandard2.0), and any customisations made to a
+        /// replaced instance are not preserved.
         /// </summary>
         HttpClient HttpClientConnection { get; }
 
         /// <summary>
-        /// Flushes/resets the current HttpClient.
+        /// Resets the connection on demand: the current <see cref="HttpClient"/> is discarded and the
+        /// next access to <see cref="HttpClientConnection"/> creates a fresh client with a fresh
+        /// connection pool, forcing DNS re-resolution. Configuration is not re-read — it is captured
+        /// once when the connection is constructed.
         /// </summary>
         void Flush();
     }

--- a/src/Enterspeed.Delivery.Sdk/Api/Extensions/EnterspeedServiceCollectionExtension.cs
+++ b/src/Enterspeed.Delivery.Sdk/Api/Extensions/EnterspeedServiceCollectionExtension.cs
@@ -1,3 +1,4 @@
+using Enterspeed.Delivery.Sdk.Api.Connection;
 using Enterspeed.Delivery.Sdk.Api.Providers;
 using Enterspeed.Delivery.Sdk.Api.Services;
 using Enterspeed.Delivery.Sdk.Configuration;
@@ -14,7 +15,13 @@ namespace Enterspeed.Delivery.Sdk.Api.Extensions
         {
             services.AddTransient<IEnterspeedDeliveryService, EnterspeedDeliveryService>();
             services.AddTransient<IJsonSerializer, SystemTextJsonSerializer>();
-            services.AddTransient<EnterspeedDeliveryConnection>();
+
+            // The connection is a thread-safe, IDisposable holder of the shared HttpClient and must be a
+            // singleton: a transient IDisposable is captured by the container for disposal on every
+            // resolution, and creating an HttpClient per resolution is the documented socket-exhaustion
+            // pattern. Configuration is captured once, when the singleton is first created.
+            services.AddSingleton<EnterspeedDeliveryConnection>();
+            services.AddSingleton<IEnterspeedDeliveryConnection>(sp => sp.GetRequiredService<EnterspeedDeliveryConnection>());
             services.AddSingleton<IEnterspeedConfigurationProvider>(new EnterspeedConfigurationProvider(enterspeedDeliveryConfiguration ?? new EnterspeedDeliveryConfiguration()));
             return services;
         }

--- a/src/Enterspeed.Delivery.Sdk/Configuration/EnterspeedDeliveryConfiguration.cs
+++ b/src/Enterspeed.Delivery.Sdk/Configuration/EnterspeedDeliveryConfiguration.cs
@@ -8,7 +8,16 @@
         public string BaseUrl { get; set; } = "https://delivery.enterspeed.com";
 
         /// <summary>
-        /// Gets or sets timeout in seconds. Default: 60 seconds.
+        /// Gets or sets the connection refresh interval in seconds. Default: 60.
+        /// This is not a request timeout: requests use <c>HttpClient.Timeout</c>, which this SDK leaves
+        /// at its default of 100 seconds.
+        /// On .NET Core 2.1+/.NET 5+ this value configures <c>SocketsHttpHandler.PooledConnectionLifetime</c>
+        /// — pooled connections are re-established at this interval so DNS changes are picked up — and
+        /// the <c>HttpClient</c> instance itself is only replaced by
+        /// <c>IEnterspeedDeliveryConnection.Flush()</c>.
+        /// On .NET Framework (the netstandard2.0 asset) it is the interval at which the internal
+        /// <c>HttpClient</c> is recreated, which is the DNS-rotation mechanism available there.
+        /// Values less than or equal to 0 are treated as 1 second.
         /// </summary>
         public int ConnectionTimeout { get; set; } = 60;
 

--- a/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Connection/EnterspeedDeliveryConnection.cs
@@ -1,17 +1,52 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Net.Http;
+using System.Threading;
 using Enterspeed.Delivery.Sdk.Api.Connection;
 using Enterspeed.Delivery.Sdk.Api.Providers;
 using Enterspeed.Delivery.Sdk.Configuration;
+
 namespace Enterspeed.Delivery.Sdk.Domain.Connection
 {
+    /// <summary>
+    /// Thread-safe holder of the SDK's shared <see cref="HttpClient"/>, intended to live as a singleton.
+    /// Configuration (<see cref="EnterspeedDeliveryConfiguration.BaseUrl"/> and
+    /// <see cref="EnterspeedDeliveryConfiguration.ConnectionTimeout"/>) is captured once at construction
+    /// and is not re-read afterwards.
+    /// </summary>
     public sealed class EnterspeedDeliveryConnection : IEnterspeedDeliveryConnection, IDisposable
     {
-        private readonly int _connectionTimeout;
-        private DateTime? _connectionEstablishedDate;
-        private HttpClient _httpClientConnection;
+        private readonly object _connectionLock = new object();
+        private readonly int _refreshIntervalSeconds;
+        private readonly Func<HttpMessageHandler> _handlerFactory;
+#if !NETCOREAPP2_1_OR_GREATER
+        private readonly Func<long> _timestampProvider;
+        private readonly long _freshnessIntervalTicks;
+#endif
+        private bool _disposed;
+
+        // The client (and, on netstandard2.0, its creation timestamp) is published as one immutable
+        // snapshot swapped by reference. The lock-free fast path reads the field with Volatile.Read and
+        // writers publish with Volatile.Write only after the snapshot is fully configured, so a reader
+        // can never observe a half-configured client or a client from one generation paired with another
+        // generation's timestamp. Storing the client and timestamp as two separate fields allowed a
+        // concurrent refresh or Flush() to interleave between the reads (observed as
+        // NullReferenceException inside DeliveryApiResponse under production load).
+        private ClientSnapshot _current;
 
         public EnterspeedDeliveryConnection(IEnterspeedConfigurationProvider configurationProvider)
+            : this(configurationProvider, null)
+        {
+        }
+
+        // Internal seams for deterministic tests, invisible to package consumers:
+        // - timestampProvider replaces Stopwatch.GetTimestamp for the netstandard2.0 timed refresh
+        //   (ignored on modern targets, which have no timed refresh);
+        // - handlerFactory replaces the HttpMessageHandler so service-level tests can run offline.
+        internal EnterspeedDeliveryConnection(
+            IEnterspeedConfigurationProvider configurationProvider,
+            Func<long> timestampProvider,
+            Func<HttpMessageHandler> handlerFactory = null)
         {
             if (configurationProvider == null)
             {
@@ -19,38 +54,119 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
             }
 
             BaseUrl = configurationProvider.Configuration?.BaseUrl;
-            _connectionTimeout = configurationProvider.Configuration?.ConnectionTimeout ?? 60;
+
+            // Values <= 0 are treated as 1 second: a zero/negative value used to mean "recreate the
+            // client on every access", which defeats connection pooling and allocates an unbounded
+            // number of clients at high request rates. Flooring instead of throwing keeps every
+            // previously accepted configuration value accepted.
+            var connectionTimeout = configurationProvider.Configuration?.ConnectionTimeout ?? 60;
+            _refreshIntervalSeconds = Math.Max(connectionTimeout, 1);
+
+#if !NETCOREAPP2_1_OR_GREATER
+            _timestampProvider = timestampProvider ?? Stopwatch.GetTimestamp;
+
+            // Guard the tick conversion against overflow (e.g. ConnectionTimeout = int.MaxValue on a
+            // high-frequency timer): a silent overflow would go negative and mean "never fresh",
+            // resurrecting the recreate-on-every-access behaviour the floor above exists to prevent.
+            _freshnessIntervalTicks = _refreshIntervalSeconds > long.MaxValue / Stopwatch.Frequency
+                ? long.MaxValue
+                : _refreshIntervalSeconds * Stopwatch.Frequency;
+#endif
+            _handlerFactory = handlerFactory;
         }
 
         private string BaseUrl { get; }
 
         public void Dispose()
         {
-            _httpClientConnection?.Dispose();
+            lock (_connectionLock)
+            {
+                if (_disposed)
+                {
+                    // Dispose must be idempotent.
+                    return;
+                }
+
+                // End-of-life disposal is intentional here, unlike the mid-life client replacement in
+                // Connect(): the owner is declaring that no further requests will be made.
+                _current?.Client.Dispose();
+                Volatile.Write(ref _current, null);
+                _disposed = true;
+            }
         }
 
+        /// <inheritdoc />
         public HttpClient HttpClientConnection
         {
             get
             {
-                if (_httpClientConnection == null
-                    || !_connectionEstablishedDate.HasValue
-                    || (DateTime.Now - _connectionEstablishedDate.Value).TotalSeconds > _connectionTimeout)
+                // Lock-free fast path: a single volatile read of the current snapshot. Volatile.Read
+                // prevents the read from being cached/hoisted; the reference itself is immutable once
+                // published.
+                var snapshot = Volatile.Read(ref _current);
+
+                if (IsFresh(snapshot))
                 {
-                    Connect();
+                    return snapshot.Client;
                 }
 
-                return _httpClientConnection;
+                lock (_connectionLock)
+                {
+                    if (_disposed)
+                    {
+                        throw new ObjectDisposedException(nameof(EnterspeedDeliveryConnection));
+                    }
+
+                    snapshot = _current;
+                    if (!IsFresh(snapshot))
+                    {
+                        snapshot = Connect();
+                    }
+
+                    return snapshot.Client;
+                }
             }
         }
 
+        /// <inheritdoc />
         public void Flush()
         {
-            _httpClientConnection = null;
-            _connectionEstablishedDate = null;
+            lock (_connectionLock)
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(nameof(EnterspeedDeliveryConnection));
+                }
+
+                // The discarded client is intentionally left to in-flight requests; see Connect() for
+                // the disposal rationale.
+                Volatile.Write(ref _current, null);
+            }
         }
 
-        private void Connect()
+        private bool IsFresh(ClientSnapshot snapshot)
+        {
+            if (snapshot == null)
+            {
+                return false;
+            }
+
+#if NETCOREAPP2_1_OR_GREATER
+            // One rotation mechanism per target: on modern runtimes the client's identity is stable
+            // between Flush() calls, and connection-level rotation (the DNS-refresh concern) is owned by
+            // SocketsHttpHandler.PooledConnectionLifetime configured in Connect(). A timed client
+            // teardown on top of that would only duplicate what the pool already does.
+            return true;
+#else
+            // netstandard2.0 has no SocketsHttpHandler, so timed client recreation is the only DNS
+            // rotation mechanism available without assuming a DI container/IHttpClientFactory. Elapsed
+            // time is measured with the monotonic Stopwatch timestamp rather than DateTime.UtcNow:
+            // wall-clock steps (NTP) must not stretch or shrink the client's lifetime.
+            return _timestampProvider() - snapshot.CreatedTimestamp < _freshnessIntervalTicks;
+#endif
+        }
+
+        private ClientSnapshot Connect()
         {
             if (string.IsNullOrWhiteSpace(BaseUrl))
             {
@@ -59,10 +175,15 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
 
             HttpClient httpClient;
 
+            var handler = _handlerFactory?.Invoke();
+
 #if NETCOREAPP2_1_OR_GREATER
-            var handler = new SocketsHttpHandler
+            // PooledConnectionLifetime is Microsoft's sanctioned DNS-rotation mechanism for a long-lived
+            // HttpClient; ConnectionTimeout configures it (previously it was hardcoded to 60 seconds and
+            // the configured value was silently ignored here).
+            handler = handler ?? new SocketsHttpHandler
             {
-                PooledConnectionLifetime = TimeSpan.FromSeconds(60)
+                PooledConnectionLifetime = TimeSpan.FromSeconds(_refreshIntervalSeconds)
             };
 
             httpClient = new HttpClient(handler)
@@ -70,17 +191,56 @@ namespace Enterspeed.Delivery.Sdk.Domain.Connection
                 BaseAddress = new Uri(BaseUrl)
             };
 #else
-            httpClient = new HttpClient
-            {
-                BaseAddress = new Uri(BaseUrl)
-            };
+            httpClient = handler != null
+                ? new HttpClient(handler)
+                : new HttpClient();
+
+            httpClient.BaseAddress = new Uri(BaseUrl);
 #endif
 
-            _httpClientConnection = httpClient;
+            // Fully configure the client BEFORE publishing it: publishing first and mutating afterwards
+            // let concurrent callers observe a half-configured client (missing Accept header) or race the
+            // non-thread-safe header collection.
+            httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
 
-            _httpClientConnection.DefaultRequestHeaders.Add("Accept", "application/json");
+            // The previous client (if any) is intentionally not disposed here: in-flight requests may
+            // still own it, and disposing it under them closes their connections and cancels their
+            // requests. Its release is therefore non-deterministic (left to garbage collection), but the
+            // abandoned handler's own pool drains via PooledConnectionLifetime/PooledConnectionIdleTimeout,
+            // and abandonment is rare: only on Flush() on modern targets, and at most once per refresh
+            // interval (floored at 1 second) on netstandard2.0. Factory-style ref-counted deferred
+            // disposal (what IHttpClientFactory does) was considered and rejected as disproportionate
+            // for this surface.
+#if NETCOREAPP2_1_OR_GREATER
+            var snapshot = new ClientSnapshot(httpClient);
+#else
+            var snapshot = new ClientSnapshot(httpClient, _timestampProvider());
+#endif
+            Volatile.Write(ref _current, snapshot);
 
-            _connectionEstablishedDate = DateTime.Now;
+            return snapshot;
+        }
+
+        // Must remain a sealed CLASS: single-reference publication is load-bearing for the lock-free
+        // fast path. As a struct the members could tear when read without the lock.
+        private sealed class ClientSnapshot
+        {
+#if NETCOREAPP2_1_OR_GREATER
+            public ClientSnapshot(HttpClient client)
+            {
+                Client = client;
+            }
+#else
+            public ClientSnapshot(HttpClient client, long createdTimestamp)
+            {
+                Client = client;
+                CreatedTimestamp = createdTimestamp;
+            }
+
+            public long CreatedTimestamp { get; }
+#endif
+
+            public HttpClient Client { get; }
         }
     }
 }

--- a/src/Enterspeed.Delivery.Sdk/Domain/Services/BaseEnterspeedDeliveryService.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Services/BaseEnterspeedDeliveryService.cs
@@ -24,6 +24,19 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
 
         protected Uri RequestUri(Action<DeliveryQueryBuilder> builder = null)
         {
+            return RequestUri(_enterspeedDeliveryConnection.HttpClientConnection, builder);
+        }
+
+        /// <summary>
+        /// Builds the request URI from the given client's base address. Capture
+        /// <see cref="EnterspeedDeliveryConnection.HttpClientConnection"/> once per operation and use the
+        /// same client to build the URI and send the request: the connection can swap clients between
+        /// getter calls (<see cref="EnterspeedDeliveryConnection.Flush"/>, or the timed refresh on the
+        /// netstandard2.0 asset), and mixing two generations within one operation is unsafe if their
+        /// configuration ever differs.
+        /// </summary>
+        protected Uri RequestUri(HttpClient client, Action<DeliveryQueryBuilder> builder = null)
+        {
             var queryBuilder = new DeliveryQueryBuilder();
             builder?.Invoke(queryBuilder);
 
@@ -33,7 +46,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
 
             if (!query.IsDeliveryApiUrl)
             {
-                requestUri = query.GetUri(_enterspeedDeliveryConnection.HttpClientConnection.BaseAddress,
+                requestUri = query.GetUri(client.BaseAddress,
                     $"/v{_configurationProvider.Configuration.DeliveryVersion}");
             }
             else
@@ -59,14 +72,16 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
 
         protected async Task<HttpResponseMessage> SendAsync(CancellationToken? cancellationToken, HttpRequestMessage requestMessage)
         {
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+
             HttpResponseMessage response;
             if (cancellationToken.HasValue)
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage, cancellationToken.Value);
+                response = await client.SendAsync(requestMessage, cancellationToken.Value);
             }
             else
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage);
+                response = await client.SendAsync(requestMessage);
             }
 
             return response;

--- a/src/Enterspeed.Delivery.Sdk/Domain/Services/EnterspeedDeliveryService.cs
+++ b/src/Enterspeed.Delivery.Sdk/Domain/Services/EnterspeedDeliveryService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -25,75 +25,87 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
             _serializer = jsonSerializer ?? throw new ArgumentNullException(nameof(jsonSerializer));
         }
 
+        // Every operation captures HttpClientConnection exactly once and uses that client both to build
+        // the request URI and to send the request: the connection can swap clients between getter calls
+        // (Flush, or the timed refresh on the netstandard2.0 asset), and mixing two generations within
+        // one operation is unsafe if their configuration ever differs.
         public async Task<DeliveryApiResponse> Fetch(string apiKey, CancellationToken cancellationToken, Action<DeliveryQueryBuilder> builder = null)
         {
             Validate(apiKey);
-            var requestUri = RequestUri(builder);
-            return await DeliveryApiResponse(apiKey, requestUri, cancellationToken);
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client, builder);
+            return await DeliveryApiResponse(client, apiKey, requestUri, cancellationToken);
         }
 
         public async Task<DeliveryApiResponse> Fetch(string apiKey, Action<DeliveryQueryBuilder> builder = null)
         {
             Validate(apiKey);
-            var requestUri = RequestUri(builder);
-            return await DeliveryApiResponse(apiKey, requestUri);
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client, builder);
+            return await DeliveryApiResponse(client, apiKey, requestUri);
         }
 
         public async Task<DeliveryApiResponse<IContent>> FetchTyped(string apiKey, CancellationToken cancellationToken, Action<DeliveryQueryBuilder> builder = null)
         {
             Validate(apiKey);
-            var requestUri = RequestUri(builder);
-            return await DeliveryApiResponseTyped(apiKey, requestUri, cancellationToken);
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client, builder);
+            return await DeliveryApiResponseTyped(client, apiKey, requestUri, cancellationToken);
         }
 
         public async Task<DeliveryApiResponse<IContent>> FetchTyped(string apiKey, Action<DeliveryQueryBuilder> builder = null)
         {
             Validate(apiKey);
-            var requestUri = RequestUri(builder);
-            return await DeliveryApiResponseTyped(apiKey, requestUri);
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client, builder);
+            return await DeliveryApiResponseTyped(client, apiKey, requestUri);
         }
 
         public async Task<DeliveryApiResponse> FetchMany(string apiKey, GetByIdsOrHandle getByIdsOrHandle, CancellationToken cancellationToken)
         {
             Validate(apiKey);
 
-            var requestUri = RequestUri();
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client);
 
             var httpContent = new StringContent(_serializer.Serialize(getByIdsOrHandle), Encoding.UTF8, "application/json");
-            return await DeliveryApiResponse(apiKey, requestUri, httpContent, cancellationToken);
+            return await DeliveryApiResponse(client, apiKey, requestUri, httpContent, cancellationToken);
         }
 
         public async Task<DeliveryApiResponse> FetchMany(string apiKey, GetByIdsOrHandle getByIdsOrHandle)
         {
             Validate(apiKey);
 
-            var requestUri = RequestUri();
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client);
 
             var httpContent = new StringContent(_serializer.Serialize(getByIdsOrHandle), Encoding.UTF8, "application/json");
-            return await DeliveryApiResponse(apiKey, requestUri, httpContent);
+            return await DeliveryApiResponse(client, apiKey, requestUri, httpContent);
         }
 
         public async Task<DeliveryApiResponse<IContent>> FetchManyTyped(string apiKey, GetByIdsOrHandle getByIdsOrHandle, CancellationToken cancellationToken)
         {
             Validate(apiKey);
 
-            var requestUri = RequestUri();
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client);
 
             var httpContent = new StringContent(_serializer.Serialize(getByIdsOrHandle), Encoding.UTF8, "application/json");
-            return await DeliveryApiResponseTyped(apiKey, requestUri, httpContent, cancellationToken);
+            return await DeliveryApiResponseTyped(client, apiKey, requestUri, httpContent, cancellationToken);
         }
 
         public async Task<DeliveryApiResponse<IContent>> FetchManyTyped(string apiKey, GetByIdsOrHandle getByIdsOrHandle)
         {
             Validate(apiKey);
 
-            var requestUri = RequestUri();
+            var client = _enterspeedDeliveryConnection.HttpClientConnection;
+            var requestUri = RequestUri(client);
 
             var httpContent = new StringContent(_serializer.Serialize(getByIdsOrHandle), Encoding.UTF8, "application/json");
-            return await DeliveryApiResponseTyped(apiKey, requestUri, httpContent);
+            return await DeliveryApiResponseTyped(client, apiKey, requestUri, httpContent);
         }
 
-        private async Task<DeliveryApiResponse<IContent>> DeliveryApiResponseTyped(string apiKey, Uri requestUri, CancellationToken? cancellationToken = null)
+        private async Task<DeliveryApiResponse<IContent>> DeliveryApiResponseTyped(HttpClient client, string apiKey, Uri requestUri, CancellationToken? cancellationToken = null)
         {
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
             {
@@ -102,11 +114,11 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
                 requestMessage.Headers.Add("X-Api-Key", apiKey);
                 if (cancellationToken.HasValue)
                 {
-                    response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage, cancellationToken.Value);
+                    response = await client.SendAsync(requestMessage, cancellationToken.Value);
                 }
                 else
                 {
-                    response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage);
+                    response = await client.SendAsync(requestMessage);
                 }
                 var responseString = await response.Content.ReadAsStringAsync();
 
@@ -124,7 +136,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
             }
         }
 
-        private async Task<DeliveryApiResponse<IContent>> DeliveryApiResponseTyped(string apiKey, Uri requestUri, HttpContent content, CancellationToken? cancellationToken = null)
+        private async Task<DeliveryApiResponse<IContent>> DeliveryApiResponseTyped(HttpClient client, string apiKey, Uri requestUri, HttpContent content, CancellationToken? cancellationToken = null)
         {
             HttpResponseMessage response;
 
@@ -132,11 +144,11 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
 
             if (cancellationToken.HasValue)
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.PostAsync(requestUri, content, cancellationToken.Value);
+                response = await client.PostAsync(requestUri, content, cancellationToken.Value);
             }
             else
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.PostAsync(requestUri, content);
+                response = await client.PostAsync(requestUri, content);
             }
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -154,7 +166,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
             };
         }
 
-        private async Task<DeliveryApiResponse> DeliveryApiResponse(string apiKey, Uri requestUri, CancellationToken? cancellationToken = null)
+        private async Task<DeliveryApiResponse> DeliveryApiResponse(HttpClient client, string apiKey, Uri requestUri, CancellationToken? cancellationToken = null)
         {
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
             {
@@ -163,11 +175,11 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
                 requestMessage.Headers.Add("X-Api-Key", apiKey);
                 if (cancellationToken.HasValue)
                 {
-                    response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage, cancellationToken.Value);
+                    response = await client.SendAsync(requestMessage, cancellationToken.Value);
                 }
                 else
                 {
-                    response = await _enterspeedDeliveryConnection.HttpClientConnection.SendAsync(requestMessage);
+                    response = await client.SendAsync(requestMessage);
                 }
 
                 var responseString = await response.Content.ReadAsStringAsync();
@@ -186,7 +198,7 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
             }
         }
 
-        private async Task<DeliveryApiResponse> DeliveryApiResponse(string apiKey, Uri requestUri, HttpContent content, CancellationToken? cancellationToken = null)
+        private async Task<DeliveryApiResponse> DeliveryApiResponse(HttpClient client, string apiKey, Uri requestUri, HttpContent content, CancellationToken? cancellationToken = null)
         {
             HttpResponseMessage response;
 
@@ -194,11 +206,11 @@ namespace Enterspeed.Delivery.Sdk.Domain.Services
 
             if (cancellationToken.HasValue)
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.PostAsync(requestUri, content, cancellationToken.Value);
+                response = await client.PostAsync(requestUri, content, cancellationToken.Value);
             }
             else
             {
-                response = await _enterspeedDeliveryConnection.HttpClientConnection.PostAsync(requestUri, content);
+                response = await client.PostAsync(requestUri, content);
             }
 
             var responseString = await response.Content.ReadAsStringAsync();

--- a/tests/Enterspeed.Delivery.Sdk.Tests/Domain/Connection/EnterspeedDeliveryConnectionTests.cs
+++ b/tests/Enterspeed.Delivery.Sdk.Tests/Domain/Connection/EnterspeedDeliveryConnectionTests.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Enterspeed.Delivery.Sdk.Api.Providers;
+using Enterspeed.Delivery.Sdk.Configuration;
+using Enterspeed.Delivery.Sdk.Domain.Connection;
+using Xunit;
+
+namespace Enterspeed.Delivery.Sdk.Tests.Domain.Connection
+{
+    public class EnterspeedDeliveryConnectionTests
+    {
+        private const string BaseUrl = "https://delivery.enterspeed.com";
+
+        private sealed class StaticConfigurationProvider : IEnterspeedConfigurationProvider
+        {
+            public StaticConfigurationProvider(int connectionTimeout)
+            {
+                Configuration = new EnterspeedDeliveryConfiguration
+                {
+                    BaseUrl = BaseUrl,
+                    ConnectionTimeout = connectionTimeout
+                };
+            }
+
+            public EnterspeedDeliveryConfiguration Configuration { get; }
+        }
+
+        /// <summary>
+        /// Deterministic fake for the connection's internal Stopwatch-timestamp seam. Seconds are
+        /// converted with the same <see cref="Stopwatch.Frequency" /> the production freshness check
+        /// uses, so the tests express time in seconds without duplicating tick arithmetic.
+        /// </summary>
+        private sealed class FakeTimestamp
+        {
+            private long _ticks;
+
+            public long Read() => Volatile.Read(ref _ticks);
+
+            public void AdvanceSeconds(double seconds) =>
+                Interlocked.Add(ref _ticks, (long)(seconds * Stopwatch.Frequency));
+        }
+
+        [Fact]
+        public void HttpClientConnection_OnFirstAccess_ReturnsFullyConfiguredClient()
+        {
+            using var connection = new EnterspeedDeliveryConnection(new StaticConfigurationProvider(60));
+
+            var client = connection.HttpClientConnection;
+
+            Assert.NotNull(client);
+            Assert.Equal(new Uri(BaseUrl), client.BaseAddress);
+            Assert.Contains("application/json", client.DefaultRequestHeaders.GetValues("Accept"));
+        }
+
+        [Fact]
+        public void HttpClientConnection_AfterFlush_ReturnsNewFullyConfiguredClient()
+        {
+            using var connection = new EnterspeedDeliveryConnection(new StaticConfigurationProvider(60));
+
+            var first = connection.HttpClientConnection;
+            connection.Flush();
+            var second = connection.HttpClientConnection;
+
+            Assert.NotNull(second);
+            Assert.NotSame(first, second);
+            Assert.Equal(new Uri(BaseUrl), second.BaseAddress);
+            Assert.Contains("application/json", second.DefaultRequestHeaders.GetValues("Accept"));
+            first.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_IsIdempotent_AndSubsequentAccessThrows()
+        {
+            var connection = new EnterspeedDeliveryConnection(new StaticConfigurationProvider(60));
+            _ = connection.HttpClientConnection;
+
+            connection.Dispose();
+            connection.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => connection.HttpClientConnection);
+            Assert.Throws<ObjectDisposedException>(() => connection.Flush());
+        }
+
+#if NET48
+        // These tests run against the SDK's netstandard2.0 asset, which is the only target with timed
+        // client recreation (no SocketsHttpHandler there, so recreating the client is its DNS-rotation
+        // mechanism). Time is driven through the internal timestamp seam — no sleeps, no wall clock.
+
+        [Fact]
+        public void HttpClientConnection_WhileWithinRefreshInterval_ReturnsSameClient()
+        {
+            var clock = new FakeTimestamp();
+            using var connection = new EnterspeedDeliveryConnection(
+                new StaticConfigurationProvider(60), clock.Read);
+
+            var first = connection.HttpClientConnection;
+            clock.AdvanceSeconds(59);
+            var second = connection.HttpClientConnection;
+
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        public void HttpClientConnection_AfterRefreshInterval_RecreatesFullyConfiguredClient()
+        {
+            var clock = new FakeTimestamp();
+            using var connection = new EnterspeedDeliveryConnection(
+                new StaticConfigurationProvider(60), clock.Read);
+
+            var first = connection.HttpClientConnection;
+            clock.AdvanceSeconds(61);
+            var second = connection.HttpClientConnection;
+
+            Assert.NotSame(first, second);
+            Assert.Equal(new Uri(BaseUrl), second.BaseAddress);
+            Assert.Contains("application/json", second.DefaultRequestHeaders.GetValues("Accept"));
+            first.Dispose();
+        }
+
+        [Fact]
+        public void HttpClientConnection_ZeroConnectionTimeout_IsFlooredToOneSecond()
+        {
+            // ConnectionTimeout <= 0 used to mean "recreate on every access", which allocates an
+            // unbounded number of clients under load. The floor turns it into a one-second interval.
+            var clock = new FakeTimestamp();
+            using var connection = new EnterspeedDeliveryConnection(
+                new StaticConfigurationProvider(0), clock.Read);
+
+            var first = connection.HttpClientConnection;
+            clock.AdvanceSeconds(0.5);
+            var withinFlooredInterval = connection.HttpClientConnection;
+            clock.AdvanceSeconds(1.0);
+            var afterFlooredInterval = connection.HttpClientConnection;
+
+            Assert.Same(first, withinFlooredInterval);
+            Assert.NotSame(first, afterFlooredInterval);
+            first.Dispose();
+        }
+#else
+        // On modern targets the client's identity is stable between Flush() calls: DNS rotation is owned
+        // by SocketsHttpHandler.PooledConnectionLifetime, not by timed client teardown. The advancing
+        // fake clock proves the timestamp seam is genuinely unused there.
+
+        [Fact]
+        public void HttpClientConnection_ClientIdentityIsStableOverTime()
+        {
+            var clock = new FakeTimestamp();
+            using var connection = new EnterspeedDeliveryConnection(
+                new StaticConfigurationProvider(1), clock.Read);
+
+            var first = connection.HttpClientConnection;
+            clock.AdvanceSeconds(TimeSpan.FromDays(365).TotalSeconds);
+            var second = connection.HttpClientConnection;
+
+            Assert.Same(first, second);
+        }
+#endif
+
+        [Fact]
+        public async Task HttpClientConnection_ConcurrentReadsAndFlushes_NeverNullOrHalfConfigured()
+        {
+            const int readersCount = 4;
+            const int readsPerReader = 5_000;
+            const int flushCount = 500;
+
+            // ConnectionTimeout = int.MaxValue makes Flush() the only invalidation trigger, so client
+            // creation is bounded by flushCount + 1 regardless of loop speed — no unbounded allocation.
+            using var connection = new EnterspeedDeliveryConnection(new StaticConfigurationProvider(int.MaxValue));
+            var created = new ConcurrentDictionary<HttpClient, byte>();
+            var failures = new ConcurrentQueue<string>();
+            using var barrier = new Barrier(readersCount + 1);
+
+            // LongRunning: dedicated threads, so blocking on the barrier cannot starve the thread pool
+            // on low-core CI agents.
+            var readers = Enumerable.Range(0, readersCount).Select(_ => Task.Factory.StartNew(
+                () =>
+                {
+                    barrier.SignalAndWait();
+                    for (var i = 0; i < readsPerReader; i++)
+                    {
+                        var client = connection.HttpClientConnection;
+                        if (client == null)
+                        {
+                            failures.Enqueue("HttpClientConnection returned null");
+                            return;
+                        }
+
+                        created.TryAdd(client, 0);
+
+                        // The Accept header must always be present: a client may never be observable half-configured.
+                        if (!client.DefaultRequestHeaders.Contains("Accept"))
+                        {
+                            failures.Enqueue("Client observed without Accept header");
+                            return;
+                        }
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default)).ToArray();
+
+            var flusher = Task.Factory.StartNew(
+                () =>
+                {
+                    barrier.SignalAndWait();
+                    for (var i = 0; i < flushCount; i++)
+                    {
+                        connection.Flush();
+                        Thread.Yield();
+                    }
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+
+            await Task.WhenAll(readers.Append(flusher));
+
+            Assert.Empty(failures);
+
+            // Boundedness, not just absence of nulls: at most one client per flush plus the initial one.
+            Assert.InRange(created.Count, 1, flushCount + 1);
+
+            // Dispose every client this test forced into existence — no finalizer flood.
+            foreach (var client in created.Keys)
+            {
+                client.Dispose();
+            }
+        }
+    }
+}

--- a/tests/Enterspeed.Delivery.Sdk.Tests/Enterspeed.Delivery.Sdk.Tests.csproj
+++ b/tests/Enterspeed.Delivery.Sdk.Tests/Enterspeed.Delivery.Sdk.Tests.csproj
@@ -1,10 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <!-- net48 runs the suite against the SDK's netstandard2.0 asset (the timed-refresh branch),
+         net6.0 against the modern asset. CI's test job runs on windows-latest, which can execute both. -->
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Lets the net48 leg compile on non-Windows dev machines (build-only; execution needs Windows/CI). -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />


### PR DESCRIPTION
## Release 1.6.0

Minor release carrying one change set: the thread-safety and client-lifetime rework of `EnterspeedDeliveryConnection` (#20). Merging this PR triggers the master build, which tags `1.6.0` and publishes to NuGet.org automatically.

## What's in it

**Fixed**
- Thread-safety races in `EnterspeedDeliveryConnection` that could intermittently surface as `NullReferenceException` inside `EnterspeedDeliveryService` under concurrent load, or let a request observe a half-configured `HttpClient`. Reported from production by a customer running the SDK at ~24 req/s. Each delivery operation now also uses a single client capture for both building the request URI and sending the request.

**Changed** (behavioural — the reason this is a minor bump, not a patch)
- On .NET Core 2.1+/.NET 5+ the `HttpClient` is no longer recreated on a timer. `ConnectionTimeout` now configures `SocketsHttpHandler.PooledConnectionLifetime` — the supported DNS-rotation mechanism for a long-lived client — where it was previously hardcoded to 60 seconds and the configured value silently ignored. Client identity is stable between `Flush()` calls.
- On .NET Framework (the netstandard2.0 asset) timed client recreation remains — it is the only rotation mechanism available there — now measured with a monotonic clock instead of the wall clock.
- `ConnectionTimeout` values ≤ 0 are treated as 1 second instead of recreating the client on every request.
- `AddEnterspeedDeliveryService` registers the connection as a **singleton** (previously transient, which is prohibited for `IDisposable` registrations) and also registers `IEnterspeedDeliveryConnection`. Configuration is captured once at first resolution.
- `EnterspeedDeliveryConnection.Dispose()` is idempotent; use after disposal throws `ObjectDisposedException`.

No public API changes — existing code compiles unchanged. Full design rationale with Microsoft-guidance citations in #20.

## Consumer notes

- Anyone constructing `EnterspeedDeliveryConnection` per-request in their own composition should switch to a single shared instance (this was always the intent; the DI extension now enforces it).
- `ConnectionTimeout` was never a request timeout — requests are governed by `HttpClient.Timeout` (default 100 s). The XML docs now say so explicitly.

## Checklist

- [x] Version bumped to 1.6.0 in `azure-pipelines.yml`
- [x] Changelog entry dated
- [x] CI green on the change set (both test target frameworks, incl. the netstandard2.0 timed-refresh branch on net48)
- [ ] After merge: verify the `1.6.0` tag and the NuGet.org listing, then back-merge master → develop
