### PR TITLE
Back-merge release 1.6.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.6.0 - 2026-07-07]
 ### Fixed
 - Fixed thread-safety races in `EnterspeedDeliveryConnection` that could intermittently surface as `NullReferenceException` inside `EnterspeedDeliveryService` under concurrent load, or let a request observe a half-configured `HttpClient`. Each delivery operation now also uses one client capture for both building the request URI and sending the request.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   majorVersion: 1
-  minorVersion: 5
+  minorVersion: 6
   patchVersion: 0
   version: $[format('{0}.{1}.{2}', variables.majorVersion, variables.minorVersion, variables.patchVersion)]
   agentPool: Enterspeed-Production


### PR DESCRIPTION
Standard gitflow back-merge after the 1.6.0 release: brings the release-branch commits (version bump to 1.6.0, dated changelog entry, release merge commit) into develop so the next release starts from a consistent base. No functional changes beyond what develop already has.